### PR TITLE
considerations for extending MINT for updating token metadata

### DIFF
--- a/slp-token-type-1.md
+++ b/slp-token-type-1.md
@@ -362,6 +362,10 @@ As with GENESIS, the MINT allows to end the baton, or further pass on the baton 
 &lt;token_id&gt; (32 bytes)<BR>
 &lt;mint_baton_vout&gt; (0 bytes or 1 byte between 0x02-0xff)<BR>
 &lt;additional_token_quantity&gt; (8 byte integer)
+&lt;token_ticker&gt; (optional, 0 to ∞ bytes, suggested utf-8)<br/>
+&lt;token_name&gt; (optional, 0 to ∞ bytes, suggested utf-8)<br/>
+&lt;token_document_url&gt; (optional, 0 to ∞ bytes, suggested ascii)<br/>
+&lt;token_document_hash&gt; (optional, 0 bytes or 32 bytes)<br/>
   </td>
     <td>any</td>
     <td>0</td>


### PR DESCRIPTION
Multiple users have requested that token details can be updated after GENESIS.  I think that we could possible allow this without making change to the type 0x01 DAG validator. 

If we append the token details to the end of the MINT message then these fields can be either provided or omitted (not even requiring a 0x4c00 null identified).

It would simply be specified that any metadata updated in a MINT transactions Shall be considered to be the most recent metadata.

EDIT
-----
The only Genesis metadata considering update would be `documentURI` and `documentSha256`.