### PR TITLE
SLP URI Scheme for payment requests

### DIFF
--- a/slp-uri-scheme.md
+++ b/slp-uri-scheme.md
@@ -4,8 +4,8 @@
 
 # URI Scheme Specificaton
 
-#### Version: 0.1
-#### Date published: TBD
+#### Version: 0.2
+#### Date published: 5-6-2019
 
 
 
@@ -44,8 +44,8 @@ Elements of the query component may contain characters outside the valid range. 
 | amountparam  | = "amount=" *digit [ "." *digit ] [ tokenid ]                |
 | multiamounts | = multiamount [ "&" multiamounts ]                           |
 | multiamount  | = "amount" *uniquechar "=" *digit [ "." *digit ] [ tokenid ] |
-| tokenid      | = ";" 64*hexchar [ ";" tokenflags ]                          |
-| tokenflags   | = tokenflag [ ";" tokenflags ]                               |
+| tokenid      | = "-" 64*hexchar [ "-" tokenflags ]                          |
+| tokenflags   | = tokenflag [ "-" tokenflags ]                               |
 | tokenflag    | = [ "isgroup" / *qchar ]                                     |
 | labelparam   | = "label=" *qchar                                            |
 | messageparam | = "message=" *qchar                                          |
@@ -73,16 +73,16 @@ Please see the BNF grammar above for the normative syntax.
     * `simpleledger:qqmtw4c35mpv5rcjnnsrskpxvzajyq3f9ygldn8fj0?label=Satoshi-Nakamoto`
 
 * **Request 10.0001 XYZ tokens to "Satoshi-Nakamoto":**
-  * `simpleledger:qqmtw4c35mpv5rcjnnsrskpxvzajyq3f9ygldn8fj0?amount_1=20.3&amount_2=10.0001;<xyzTokenID>&label=Satoshi-Nakamoto`
+  * `simpleledger:qqmtw4c35mpv5rcjnnsrskpxvzajyq3f9ygldn8fj0?amount1=20.3&amount2=10.0001-<xyzTokenID>&label=Satoshi-Nakamoto`
 
 * **Request 20.30 BCH & 1000 XYZ tokens to "Satoshi-Nakamoto":**
-  * `simpleledger:qqmtw4c35mpv5rcjnnsrskpxvzajyq3f9ygldn8fj0?amount_1=20.3&amount_2=1000;<xyzTokenID>&label=Satoshi-Nakamoto`
+  * `simpleledger:qqmtw4c35mpv5rcjnnsrskpxvzajyq3f9ygldn8fj0?amount1=20.3&amount2=1000-<xyzTokenID>&label=Satoshi-Nakamoto`
 
 * **Request 50 BCH & 1 ABC token with message:**
-  * `simpleledger:qqmtw4c35mpv5rcjnnsrskpxvzajyq3f9ygldn8fj0?amount_1=50&amount_2=1;<abcTokenID>&label=Satoshi-Nakamoto&message=Donation%20for%20project%20xyz`
+  * `simpleledger:qqmtw4c35mpv5rcjnnsrskpxvzajyq3f9ygldn8fj0?amount1=50&amount2=1-<abcTokenID>&label=Satoshi-Nakamoto&message=Donation%20for%20project%20xyz`
 
 * **Request any 1 NFT token from group XYZ (using "isgroup"):**
-  * `simpleledger:qqmtw4c35mpv5rcjnnsrskpxvzajyq3f9ygldn8fj0?amount_1=1&amount_2=1;<xyzGroupID>;isgroup&label=Satoshi-Nakamoto`
+  * `simpleledger:qqmtw4c35mpv5rcjnnsrskpxvzajyq3f9ygldn8fj0?amount1=1&amount2=1-<xyzGroupID>-isgroup&label=Satoshi-Nakamoto`
 
 * **Some future version that has variables which are (currently) not understood and required and thus invalid:**
   * `simpleledger:qqmtw4c35mpv5rcjnnsrskpxvzajyq3f9ygldn8fj0?req-somethingyoudontunderstand=50&req-somethingelseyoudontget=999`

--- a/slp-uri-scheme.md
+++ b/slp-uri-scheme.md
@@ -76,13 +76,16 @@ Please see the BNF grammar above for the normative syntax.
 	* `simpleledger:qqmtw4c35mpv5rcjnnsrskpxvzajyq3f9ygldn8fj0?label=Satoshi-Nakamoto`
 
 * **Request 10.0001 XYZ tokens to "Satoshi-Nakamoto":**
-  * `simpleledger:qqmtw4c35mpv5rcjnnsrskpxvzajyq3f9ygldn8fj0?amount=20.3&amount=<xyzTokenID>:10.0001&label=Satoshi-Nakamoto`
+  * `simpleledger:qqmtw4c35mpv5rcjnnsrskpxvzajyq3f9ygldn8fj0?amount=20.3&amount=10.0001:<xyzTokenID>&label=Satoshi-Nakamoto`
 
 * **Request 20.30 BCH & 1000 XYZ tokens to "Satoshi-Nakamoto":**
-  * `simpleledger:qqmtw4c35mpv5rcjnnsrskpxvzajyq3f9ygldn8fj0?amount=20.3&amount=<xyzTokenID>:1000&label=Satoshi-Nakamoto`
+  * `simpleledger:qqmtw4c35mpv5rcjnnsrskpxvzajyq3f9ygldn8fj0?amount=20.3&amount=1000:<xyzTokenID>&label=Satoshi-Nakamoto`
 
 * **Request 50 BCH & 1 ABC token with message:**
-  * `simpleledger:qqmtw4c35mpv5rcjnnsrskpxvzajyq3f9ygldn8fj0?amount=50&amount=<abcTokenID>:1&label=Satoshi-Nakamoto&message=Donation%20for%20project%20xyz`
+  * `simpleledger:qqmtw4c35mpv5rcjnnsrskpxvzajyq3f9ygldn8fj0?amount=50&amount=1:<abcTokenID>&label=Satoshi-Nakamoto&message=Donation%20for%20project%20xyz`
+
+* **Request any 1 NFT token from group XYZ (using "nftfromgroup"):**
+  * `simpleledger:qqmtw4c35mpv5rcjnnsrskpxvzajyq3f9ygldn8fj0?amount=1&amount=1:<xyzGroupID>:nftfromgroup&label=Satoshi-Nakamoto`
 
 * **Some future version that has variables which are (currently) not understood and required and thus invalid:**
   * `simpleledger:qqmtw4c35mpv5rcjnnsrskpxvzajyq3f9ygldn8fj0?req-somethingyoudontunderstand=50&req-somethingelseyoudontget=999`

--- a/slp-uri-scheme.md
+++ b/slp-uri-scheme.md
@@ -35,7 +35,6 @@ Elements of the query component may contain characters outside the valid range. 
 ### ABNF grammar
 
 
-
 | Placeholder  | Format                                                       |
 | ------------ | ------------------------------------------------------------ |
 | slpurn       | = "simpleledger:" address [ "?" params ]                     |
@@ -44,7 +43,7 @@ Elements of the query component may contain characters outside the valid range. 
 | param        | = [chainid / amountparams / labelparam / messageparam / otherparam / reqparam] |
 | chainid      | = "chain=" *qchar                                            |
 | amountparams | = amountparam [ "&" amountparams ]                           |
-| amountparam  | = "amount=" *digit [ "." *digit / tokenid / amountmode ]     |
+| amountparam  | = "amount_" *uniquechar "=" *digit [ "." *digit / tokenid / amountmode ]     |
 | tokenid      | = ";" 64*hexchar                                             |
 | amountmode   | = ";nftfromgroup"                                            |
 | labelparam   | = "label=" *qchar                                            |
@@ -76,16 +75,16 @@ Please see the BNF grammar above for the normative syntax.
 	* `simpleledger:qqmtw4c35mpv5rcjnnsrskpxvzajyq3f9ygldn8fj0?label=Satoshi-Nakamoto`
 
 * **Request 10.0001 XYZ tokens to "Satoshi-Nakamoto":**
-  * `simpleledger:qqmtw4c35mpv5rcjnnsrskpxvzajyq3f9ygldn8fj0?amount=20.3&amount=10.0001;<xyzTokenID>&label=Satoshi-Nakamoto`
+  * `simpleledger:qqmtw4c35mpv5rcjnnsrskpxvzajyq3f9ygldn8fj0?amount_1=20.3&amount_2=10.0001;<xyzTokenID>&label=Satoshi-Nakamoto`
 
 * **Request 20.30 BCH & 1000 XYZ tokens to "Satoshi-Nakamoto":**
-  * `simpleledger:qqmtw4c35mpv5rcjnnsrskpxvzajyq3f9ygldn8fj0?amount=20.3&amount=1000;<xyzTokenID>&label=Satoshi-Nakamoto`
+  * `simpleledger:qqmtw4c35mpv5rcjnnsrskpxvzajyq3f9ygldn8fj0?amount_1=20.3&amount_2=1000;<xyzTokenID>&label=Satoshi-Nakamoto`
 
 * **Request 50 BCH & 1 ABC token with message:**
-  * `simpleledger:qqmtw4c35mpv5rcjnnsrskpxvzajyq3f9ygldn8fj0?amount=50&amount=1;<abcTokenID>&label=Satoshi-Nakamoto&message=Donation%20for%20project%20xyz`
+  * `simpleledger:qqmtw4c35mpv5rcjnnsrskpxvzajyq3f9ygldn8fj0?amount_1=50&amount_2=1;<abcTokenID>&label=Satoshi-Nakamoto&message=Donation%20for%20project%20xyz`
 
 * **Request any 1 NFT token from group XYZ (using "nftfromgroup"):**
-  * `simpleledger:qqmtw4c35mpv5rcjnnsrskpxvzajyq3f9ygldn8fj0?amount=1&amount=1;<xyzGroupID>;nftfromgroup&label=Satoshi-Nakamoto`
+  * `simpleledger:qqmtw4c35mpv5rcjnnsrskpxvzajyq3f9ygldn8fj0?amount_1=1&amount_2=1;<xyzGroupID>;nftfromgroup&label=Satoshi-Nakamoto`
 
 * **Some future version that has variables which are (currently) not understood and required and thus invalid:**
   * `simpleledger:qqmtw4c35mpv5rcjnnsrskpxvzajyq3f9ygldn8fj0?req-somethingyoudontunderstand=50&req-somethingelseyoudontget=999`

--- a/slp-uri-scheme.md
+++ b/slp-uri-scheme.md
@@ -1,0 +1,98 @@
+![Simple Ledger Protocol](images/SLP-logo-solid-200.png)
+
+
+
+# URI Scheme Specificaton
+
+#### Version: 0.1
+#### Date published: TBD
+
+
+
+## Purpose
+
+The purpose of this URI scheme is to enable users to easily make SLP token & cryptocurrency payments by simply clicking links on webpages or scanning QR Codes.
+
+
+
+## Specification
+
+### General rules for handling (important!)
+
+SLP clients MUST NOT act on URIs without getting the user's authorization.
+They SHOULD require the user to manually approve each payment individually, though in some cases they MAY allow the user to automatically make this decision.
+
+### Operating system integration
+
+Graphical SLP clients SHOULD register themselves as the handler for the "simpleledger:" URI scheme by default, if no other handler is already registered. If there is already a registered handler, they MAY prompt the user to change it once when they first run the client.
+
+### General Format
+
+SLP URIs follow the general format for URIs as set forth in RFC 3986. The path component consists of a simpleledger address, and the query component provides additional payment options.
+
+Elements of the query component may contain characters outside the valid range. These must first be encoded according to UTF-8, and then each octet of the corresponding UTF-8 sequence must be percent-encoded as described in RFC 3986.
+
+### ABNF grammar
+
+
+
+| Placeholder  | Format                                                       |
+| ------------ | ------------------------------------------------------------ |
+| slpurn       | = "simpleledger:" address [ "?" params ]                     |
+| address      | = *slpaddr                                                   |
+| params       | = param [ "&" params ]                                       |
+| param        | = [chainid / amountparams / labelparam / messageparam / otherparam / reqparam] |
+| chainid      | = "chain=" *qchar                                            |
+| amountparams | = amountparam [ "&" amountparams ]                           |
+| amountparam  | = "amount=" [ tokenid ] *digit [ "." *digit ]                |
+| tokenid      | = *qchar ":"                                                 |
+| labelparam   | = "label=" *qchar                                            |
+| messageparam | = "message=" *qchar                                          |
+| otherparam   | = qchar *qchar [ "=" *qchar ]                                |
+| reqparam     | = "req-" qchar *qchar [ "=" *qchar ]                         |
+
+
+
+
+### Implementation Requirements
+
+1. Bitcoin Cash is the default blockchain using this URI scheme and the value "chain=BCH" is assumed if the `chainid` parameter is omitted. Even though Bitcoin Cash is the default blockchain it can still be included by using `chainid=BCH`.
+2. If the `tokenid` field is omitted within `amountparam`, an amount request for `chainid` currency shall be inferred.
+3. If the `tokenid` field is provided within `amountparam`, an amount request for `tokenid` token residing on the `chainid` blockchain shall be inferred.
+4. The `*slpaddr` address format is specified [here](https://github.com/simpleledger/slp-specifications/blob/master/slp-token-type-1.md#slp-addr).
+
+### Examples
+
+This section is non-normative and does not cover all possible syntax.
+Please see the BNF grammar above for the normative syntax.
+
+* **Just the address:**
+  * `simpleledger:qqmtw4c35mpv5rcjnnsrskpxvzajyq3f9ygldn8fj0`
+
+* **Address with name:**
+	* `simpleledger:qqmtw4c35mpv5rcjnnsrskpxvzajyq3f9ygldn8fj0?label=Satoshi-Nakamoto`
+	
+* **Request 10.0001 XYZ tokens to "Satoshi-Nakamoto":**
+  * `simpleledger:qqmtw4c35mpv5rcjnnsrskpxvzajyq3f9ygldn8fj0?amount=20.3&amount=<xyzTokenID>:10.0001&label=Satoshi-Nakamoto`
+
+* **Request 20.30 BCH & 1000 XYZ tokens to "Satoshi-Nakamoto":**
+  * `simpleledger:qqmtw4c35mpv5rcjnnsrskpxvzajyq3f9ygldn8fj0?amount=20.3&amount=<xyzTokenID>:1000&label=Satoshi-Nakamoto`
+
+* **Request 50 BCH & 1 ABC token with message:**
+  * `simpleledger:qqmtw4c35mpv5rcjnnsrskpxvzajyq3f9ygldn8fj0?amount=50&amount=<abcTokenID>:1&label=Satoshi-Nakamoto&message=Donation%20for%20project%20xyz`
+
+* **Some future version that has variables which are (currently) not understood and required and thus invalid:**
+  * `simpleledger:qqmtw4c35mpv5rcjnnsrskpxvzajyq3f9ygldn8fj0?req-somethingyoudontunderstand=50&req-somethingelseyoudontget=999`
+
+* **Some future version that has variables which are (currently) not understood but not required and thus valid:**
+  * `simpleledger:qqmtw4c35mpv5rcjnnsrskpxvzajyq3f9ygldn8fj0?somethingyoudontunderstand=50&somethingelseyoudontget=999`
+
+
+
+## Reference Implementations
+
+### Clients
+None currently
+
+### Libraries
+None currently

--- a/slp-uri-scheme.md
+++ b/slp-uri-scheme.md
@@ -11,7 +11,7 @@
 
 ## Purpose
 
-The purpose of this URI scheme is to enable users to easily make SLP token & cryptocurrency payments by simply clicking links on webpages or scanning QR Codes.
+The purpose of this URI scheme is to enable users to easily make SLP token & Bitcoin Cash payments by simply clicking links on webpages or scanning QR Codes.
 
 
 
@@ -40,12 +40,13 @@ Elements of the query component may contain characters outside the valid range. 
 | slpurn       | = "simpleledger:" address [ "?" params ]                     |
 | address      | = *slpaddr                                                   |
 | params       | = param [ "&" params ]                                       |
-| param        | = [chainid / amountparams / labelparam / messageparam / otherparam / reqparam] |
-| chainid      | = "chain=" *qchar                                            |
-| amountparams | = amountparam [ "&" amountparams ]                           |
-| amountparam  | = "amount_" *uniquechar "=" *digit [ "." *digit / tokenid / amountmode ]     |
+| param        | = [ amountparam / multiamounts / labelparam / messageparam / otherparam / reqparam ] |
+| amountparam  | = "amount=" *digit [ "." *digit ] [ tokenid / amountflags ]  |
+| multiamounts | = multiamount [ "&" multiamounts ]                           |
+| multiamount  | = "amount" *uniquechar "=" *digit [ "." *digit / tokenid / amountflags ] |
 | tokenid      | = ";" 64*hexchar                                             |
-| amountmode   | = ";nftfromgroup"                                            |
+| amountflags  | = ";" amountflags [ ";" amountflags ]                        |
+| amountflag   | = [ "isgroup" / *qchar ]                                     |
 | labelparam   | = "label=" *qchar                                            |
 | messageparam | = "message=" *qchar                                          |
 | otherparam   | = qchar *qchar [ "=" *qchar ]                                |
@@ -56,12 +57,9 @@ Elements of the query component may contain characters outside the valid range. 
 
 ### Implementation Requirements
 
-1. Bitcoin Cash is the default blockchain using this URI scheme and the value "chain=BCH" is assumed if the `chainid` parameter is omitted. Even though Bitcoin Cash is the default blockchain it can still be included (i.e., `chain=BCH`).
-2. If the `tokenid` field is omitted within `amountparam`, an amount request for `chainid` currency shall be inferred.
-3. If the `tokenid` field is provided within `amountparam`, an amount request for `tokenid` token residing on the `chainid` blockchain shall be inferred.
-4. Only a single `amountparam` parameter can be provided for each `tokenid`, and only a single amount for the base currency shall be made.
-5. If `amountmode` is omitted from the `amountparam` parameter then the payment shall be made using the tokenid specified.  If ":nftfromgroup" is provided for `amountmode` then the payment request can satisfied using any valid NFT originating from the NFT group tokenid provided.  Read NFT group specification [here](https://github.com/simpleledger/slp-specifications/blob/master/NFT.md#extension-groupable-supply-limitable-nft-tokens-as-a-derivative-of-fungible-tokens) for more information.  In the future other `amountmode` options may be possible.
-6. The `*slpaddr` address format is specified [here](https://github.com/simpleledger/slp-specifications/blob/master/slp-token-type-1.md#slp-addr).
+1. Bitcoin Cash is the blockchain associated with the "simpleledger" URI scheme.
+2. If `amountflags` is omitted the payment shall be made using the tokenid specified.  However, if the `isgroup` amountflag option is provided then the payment request can satisfied using any valid NFT originating from the NFT group tokenid provided.  Read NFT group specification [here](https://github.com/simpleledger/slp-specifications/blob/master/NFT.md#extension-groupable-supply-limitable-nft-tokens-as-a-derivative-of-fungible-tokens) for more information.  In the future additional `amountflag` options may be possible.
+3. The character set requirements for the `*slpaddr` address format are specified [here](https://github.com/simpleledger/slp-specifications/blob/master/slp-token-type-1.md#slp-addr).
 
 ### Examples
 
@@ -72,7 +70,7 @@ Please see the BNF grammar above for the normative syntax.
   * `simpleledger:qqmtw4c35mpv5rcjnnsrskpxvzajyq3f9ygldn8fj0`
 
 * **Address with name:**
-	* `simpleledger:qqmtw4c35mpv5rcjnnsrskpxvzajyq3f9ygldn8fj0?label=Satoshi-Nakamoto`
+    * `simpleledger:qqmtw4c35mpv5rcjnnsrskpxvzajyq3f9ygldn8fj0?label=Satoshi-Nakamoto`
 
 * **Request 10.0001 XYZ tokens to "Satoshi-Nakamoto":**
   * `simpleledger:qqmtw4c35mpv5rcjnnsrskpxvzajyq3f9ygldn8fj0?amount_1=20.3&amount_2=10.0001;<xyzTokenID>&label=Satoshi-Nakamoto`
@@ -83,8 +81,8 @@ Please see the BNF grammar above for the normative syntax.
 * **Request 50 BCH & 1 ABC token with message:**
   * `simpleledger:qqmtw4c35mpv5rcjnnsrskpxvzajyq3f9ygldn8fj0?amount_1=50&amount_2=1;<abcTokenID>&label=Satoshi-Nakamoto&message=Donation%20for%20project%20xyz`
 
-* **Request any 1 NFT token from group XYZ (using "nftfromgroup"):**
-  * `simpleledger:qqmtw4c35mpv5rcjnnsrskpxvzajyq3f9ygldn8fj0?amount_1=1&amount_2=1;<xyzGroupID>;nftfromgroup&label=Satoshi-Nakamoto`
+* **Request any 1 NFT token from group XYZ (using "isgroup"):**
+  * `simpleledger:qqmtw4c35mpv5rcjnnsrskpxvzajyq3f9ygldn8fj0?amount_1=1&amount_2=1;<xyzGroupID>;isgroup&label=Satoshi-Nakamoto`
 
 * **Some future version that has variables which are (currently) not understood and required and thus invalid:**
   * `simpleledger:qqmtw4c35mpv5rcjnnsrskpxvzajyq3f9ygldn8fj0?req-somethingyoudontunderstand=50&req-somethingelseyoudontget=999`
@@ -97,7 +95,7 @@ Please see the BNF grammar above for the normative syntax.
 ## Reference Implementations
 
 ### Clients
-None currently
+Electron Cash SLP - WIP
 
 ### Libraries
 None currently

--- a/slp-uri-scheme.md
+++ b/slp-uri-scheme.md
@@ -43,10 +43,10 @@ Elements of the query component may contain characters outside the valid range. 
 | param        | = [ amountparam / multiamounts / labelparam / messageparam / otherparam / reqparam ] |
 | amountparam  | = "amount=" *digit [ "." *digit ] [ tokenid / amountflags ]  |
 | multiamounts | = multiamount [ "&" multiamounts ]                           |
-| multiamount  | = "amount" *uniquechar "=" *digit [ "." *digit / tokenid / amountflags ] |
-| tokenid      | = ";" 64*hexchar                                             |
-| amountflags  | = ";" amountflag [ ";" amountflags ]                         |
-| amountflag   | = [ "isgroup" / *qchar ]                                     |
+| multiamount  | = "amount" *uniquechar "=" *digit [ "." *digit / tokenid ]   |
+| tokenid      | = ";" 64*hexchar [ ";" tokenflags ]                              |
+| tokenflags   | = tokenflag [ ";" tokenflags ]                           |
+| tokenflags   | = [ "isgroup" / *qchar ]                                     |
 | labelparam   | = "label=" *qchar                                            |
 | messageparam | = "message=" *qchar                                          |
 | otherparam   | = qchar *qchar [ "=" *qchar ]                                |
@@ -58,7 +58,7 @@ Elements of the query component may contain characters outside the valid range. 
 ### Implementation Requirements
 
 1. Bitcoin Cash is the blockchain associated with the "simpleledger" URI scheme.
-2. If `amountflags` is omitted the payment shall be made using the tokenid specified.  However, if the `isgroup` amountflag option is provided then the payment request can satisfied using any valid NFT originating from the NFT group tokenid provided.  Read NFT group specification [here](https://github.com/simpleledger/slp-specifications/blob/master/NFT.md#extension-groupable-supply-limitable-nft-tokens-as-a-derivative-of-fungible-tokens) for more information.  In the future additional `amountflag` options may be possible.
+2. If `tokenflags` is omitted the payment shall be made using the tokenid specified.  However, if the `isgroup` tokenflag option is provided then the payment request can satisfied using any valid NFT originating from the NFT group tokenid provided.  Read NFT group specification [here](https://github.com/simpleledger/slp-specifications/blob/master/NFT.md#extension-groupable-supply-limitable-nft-tokens-as-a-derivative-of-fungible-tokens) for more information.  In the future additional `tokenflag` options may be possible.
 3. The character set requirements for the `*slpaddr` address format are specified [here](https://github.com/simpleledger/slp-specifications/blob/master/slp-token-type-1.md#slp-addr).
 
 ### Examples

--- a/slp-uri-scheme.md
+++ b/slp-uri-scheme.md
@@ -45,7 +45,7 @@ Elements of the query component may contain characters outside the valid range. 
 | multiamounts | = multiamount [ "&" multiamounts ]                           |
 | multiamount  | = "amount" *uniquechar "=" *digit [ "." *digit / tokenid / amountflags ] |
 | tokenid      | = ";" 64*hexchar                                             |
-| amountflags  | = ";" amountflags [ ";" amountflags ]                        |
+| amountflags  | = ";" amountflag [ ";" amountflags ]                         |
 | amountflag   | = [ "isgroup" / *qchar ]                                     |
 | labelparam   | = "label=" *qchar                                            |
 | messageparam | = "message=" *qchar                                          |

--- a/slp-uri-scheme.md
+++ b/slp-uri-scheme.md
@@ -41,9 +41,9 @@ Elements of the query component may contain characters outside the valid range. 
 | address      | = *slpaddr                                                   |
 | params       | = param [ "&" params ]                                       |
 | param        | = [ amountparam / multiamounts / labelparam / messageparam / otherparam / reqparam ] |
-| amountparam  | = "amount=" *digit [ "." *digit ] [ tokenid / amountflags ]  |
+| amountparam  | = "amount=" *digit [ "." *digit ] [ tokenid ]                |
 | multiamounts | = multiamount [ "&" multiamounts ]                           |
-| multiamount  | = "amount" *uniquechar "=" *digit [ "." *digit / tokenid ]   |
+| multiamount  | = "amount" *uniquechar "=" *digit [ "." *digit ] [ tokenid ] |
 | tokenid      | = ";" 64*hexchar [ ";" tokenflags ]                          |
 | tokenflags   | = tokenflag [ ";" tokenflags ]                               |
 | tokenflag    | = [ "isgroup" / *qchar ]                                     |

--- a/slp-uri-scheme.md
+++ b/slp-uri-scheme.md
@@ -44,9 +44,9 @@ Elements of the query component may contain characters outside the valid range. 
 | amountparam  | = "amount=" *digit [ "." *digit ] [ tokenid / amountflags ]  |
 | multiamounts | = multiamount [ "&" multiamounts ]                           |
 | multiamount  | = "amount" *uniquechar "=" *digit [ "." *digit / tokenid ]   |
-| tokenid      | = ";" 64*hexchar [ ";" tokenflags ]                              |
-| tokenflags   | = tokenflag [ ";" tokenflags ]                           |
-| tokenflags   | = [ "isgroup" / *qchar ]                                     |
+| tokenid      | = ";" 64*hexchar [ ";" tokenflags ]                          |
+| tokenflags   | = tokenflag [ ";" tokenflags ]                               |
+| tokenflag    | = [ "isgroup" / *qchar ]                                     |
 | labelparam   | = "label=" *qchar                                            |
 | messageparam | = "message=" *qchar                                          |
 | otherparam   | = qchar *qchar [ "=" *qchar ]                                |

--- a/slp-uri-scheme.md
+++ b/slp-uri-scheme.md
@@ -45,8 +45,8 @@ Elements of the query component may contain characters outside the valid range. 
 | chainid      | = "chain=" *qchar                                            |
 | amountparams | = amountparam [ "&" amountparams ]                           |
 | amountparam  | = "amount=" *digit [ "." *digit / tokenid / amountmode ]     |
-| tokenid      | = "-" *qchar                                                 |
-| amountmode   | = "-nftfromgroup"                                            |
+| tokenid      | = ";" 64*hexchar                                             |
+| amountmode   | = ";nftfromgroup"                                            |
 | labelparam   | = "label=" *qchar                                            |
 | messageparam | = "message=" *qchar                                          |
 | otherparam   | = qchar *qchar [ "=" *qchar ]                                |
@@ -76,16 +76,16 @@ Please see the BNF grammar above for the normative syntax.
 	* `simpleledger:qqmtw4c35mpv5rcjnnsrskpxvzajyq3f9ygldn8fj0?label=Satoshi-Nakamoto`
 
 * **Request 10.0001 XYZ tokens to "Satoshi-Nakamoto":**
-  * `simpleledger:qqmtw4c35mpv5rcjnnsrskpxvzajyq3f9ygldn8fj0?amount=20.3&amount=10.0001-<xyzTokenID>&label=Satoshi-Nakamoto`
+  * `simpleledger:qqmtw4c35mpv5rcjnnsrskpxvzajyq3f9ygldn8fj0?amount=20.3&amount=10.0001;<xyzTokenID>&label=Satoshi-Nakamoto`
 
 * **Request 20.30 BCH & 1000 XYZ tokens to "Satoshi-Nakamoto":**
-  * `simpleledger:qqmtw4c35mpv5rcjnnsrskpxvzajyq3f9ygldn8fj0?amount=20.3&amount=1000-<xyzTokenID>&label=Satoshi-Nakamoto`
+  * `simpleledger:qqmtw4c35mpv5rcjnnsrskpxvzajyq3f9ygldn8fj0?amount=20.3&amount=1000;<xyzTokenID>&label=Satoshi-Nakamoto`
 
 * **Request 50 BCH & 1 ABC token with message:**
-  * `simpleledger:qqmtw4c35mpv5rcjnnsrskpxvzajyq3f9ygldn8fj0?amount=50&amount=1-<abcTokenID>&label=Satoshi-Nakamoto&message=Donation%20for%20project%20xyz`
+  * `simpleledger:qqmtw4c35mpv5rcjnnsrskpxvzajyq3f9ygldn8fj0?amount=50&amount=1;<abcTokenID>&label=Satoshi-Nakamoto&message=Donation%20for%20project%20xyz`
 
 * **Request any 1 NFT token from group XYZ (using "nftfromgroup"):**
-  * `simpleledger:qqmtw4c35mpv5rcjnnsrskpxvzajyq3f9ygldn8fj0?amount=1&amount=1-<xyzGroupID>-nftfromgroup&label=Satoshi-Nakamoto`
+  * `simpleledger:qqmtw4c35mpv5rcjnnsrskpxvzajyq3f9ygldn8fj0?amount=1&amount=1;<xyzGroupID>;nftfromgroup&label=Satoshi-Nakamoto`
 
 * **Some future version that has variables which are (currently) not understood and required and thus invalid:**
   * `simpleledger:qqmtw4c35mpv5rcjnnsrskpxvzajyq3f9ygldn8fj0?req-somethingyoudontunderstand=50&req-somethingelseyoudontget=999`

--- a/slp-uri-scheme.md
+++ b/slp-uri-scheme.md
@@ -45,8 +45,8 @@ Elements of the query component may contain characters outside the valid range. 
 | chainid      | = "chain=" *qchar                                            |
 | amountparams | = amountparam [ "&" amountparams ]                           |
 | amountparam  | = "amount=" *digit [ "." *digit / tokenid / amountmode ]     |
-| tokenid      | = ":" *qchar                                                 |
-| amountmode   | = ":nftfromgroup"                                            |
+| tokenid      | = "-" *qchar                                                 |
+| amountmode   | = "-nftfromgroup"                                            |
 | labelparam   | = "label=" *qchar                                            |
 | messageparam | = "message=" *qchar                                          |
 | otherparam   | = qchar *qchar [ "=" *qchar ]                                |
@@ -76,16 +76,16 @@ Please see the BNF grammar above for the normative syntax.
 	* `simpleledger:qqmtw4c35mpv5rcjnnsrskpxvzajyq3f9ygldn8fj0?label=Satoshi-Nakamoto`
 
 * **Request 10.0001 XYZ tokens to "Satoshi-Nakamoto":**
-  * `simpleledger:qqmtw4c35mpv5rcjnnsrskpxvzajyq3f9ygldn8fj0?amount=20.3&amount=10.0001:<xyzTokenID>&label=Satoshi-Nakamoto`
+  * `simpleledger:qqmtw4c35mpv5rcjnnsrskpxvzajyq3f9ygldn8fj0?amount=20.3&amount=10.0001-<xyzTokenID>&label=Satoshi-Nakamoto`
 
 * **Request 20.30 BCH & 1000 XYZ tokens to "Satoshi-Nakamoto":**
-  * `simpleledger:qqmtw4c35mpv5rcjnnsrskpxvzajyq3f9ygldn8fj0?amount=20.3&amount=1000:<xyzTokenID>&label=Satoshi-Nakamoto`
+  * `simpleledger:qqmtw4c35mpv5rcjnnsrskpxvzajyq3f9ygldn8fj0?amount=20.3&amount=1000-<xyzTokenID>&label=Satoshi-Nakamoto`
 
 * **Request 50 BCH & 1 ABC token with message:**
-  * `simpleledger:qqmtw4c35mpv5rcjnnsrskpxvzajyq3f9ygldn8fj0?amount=50&amount=1:<abcTokenID>&label=Satoshi-Nakamoto&message=Donation%20for%20project%20xyz`
+  * `simpleledger:qqmtw4c35mpv5rcjnnsrskpxvzajyq3f9ygldn8fj0?amount=50&amount=1-<abcTokenID>&label=Satoshi-Nakamoto&message=Donation%20for%20project%20xyz`
 
 * **Request any 1 NFT token from group XYZ (using "nftfromgroup"):**
-  * `simpleledger:qqmtw4c35mpv5rcjnnsrskpxvzajyq3f9ygldn8fj0?amount=1&amount=1:<xyzGroupID>:nftfromgroup&label=Satoshi-Nakamoto`
+  * `simpleledger:qqmtw4c35mpv5rcjnnsrskpxvzajyq3f9ygldn8fj0?amount=1&amount=1-<xyzGroupID>-nftfromgroup&label=Satoshi-Nakamoto`
 
 * **Some future version that has variables which are (currently) not understood and required and thus invalid:**
   * `simpleledger:qqmtw4c35mpv5rcjnnsrskpxvzajyq3f9ygldn8fj0?req-somethingyoudontunderstand=50&req-somethingelseyoudontget=999`

--- a/slp-uri-scheme.md
+++ b/slp-uri-scheme.md
@@ -44,8 +44,9 @@ Elements of the query component may contain characters outside the valid range. 
 | param        | = [chainid / amountparams / labelparam / messageparam / otherparam / reqparam] |
 | chainid      | = "chain=" *qchar                                            |
 | amountparams | = amountparam [ "&" amountparams ]                           |
-| amountparam  | = "amount=" [ tokenid ] *digit [ "." *digit ]                |
-| tokenid      | = *qchar ":"                                                 |
+| amountparam  | = "amount=" *digit [ "." *digit / tokenid / amountmode ]     |
+| tokenid      | = ":" *qchar                                                 |
+| amountmode   | = ":nftfromgroup"                                            |
 | labelparam   | = "label=" *qchar                                            |
 | messageparam | = "message=" *qchar                                          |
 | otherparam   | = qchar *qchar [ "=" *qchar ]                                |
@@ -56,10 +57,12 @@ Elements of the query component may contain characters outside the valid range. 
 
 ### Implementation Requirements
 
-1. Bitcoin Cash is the default blockchain using this URI scheme and the value "chain=BCH" is assumed if the `chainid` parameter is omitted. Even though Bitcoin Cash is the default blockchain it can still be included by using `chainid=BCH`.
+1. Bitcoin Cash is the default blockchain using this URI scheme and the value "chain=BCH" is assumed if the `chainid` parameter is omitted. Even though Bitcoin Cash is the default blockchain it can still be included (i.e., `chain=BCH`).
 2. If the `tokenid` field is omitted within `amountparam`, an amount request for `chainid` currency shall be inferred.
 3. If the `tokenid` field is provided within `amountparam`, an amount request for `tokenid` token residing on the `chainid` blockchain shall be inferred.
-4. The `*slpaddr` address format is specified [here](https://github.com/simpleledger/slp-specifications/blob/master/slp-token-type-1.md#slp-addr).
+4. Only a single `amountparam` parameter can be provided for each `tokenid`, and only a single amount for the base currency shall be made.
+5. If `amountmode` is omitted from the `amountparam` parameter then the payment shall be made using the tokenid specified.  If ":nftfromgroup" is provided for `amountmode` then the payment request can satisfied using any valid NFT originating from the NFT group tokenid provided.  Read NFT group specification [here](https://github.com/simpleledger/slp-specifications/blob/master/NFT.md#extension-groupable-supply-limitable-nft-tokens-as-a-derivative-of-fungible-tokens) for more information.  In the future other `amountmode` options may be possible.
+6. The `*slpaddr` address format is specified [here](https://github.com/simpleledger/slp-specifications/blob/master/slp-token-type-1.md#slp-addr).
 
 ### Examples
 
@@ -71,7 +74,7 @@ Please see the BNF grammar above for the normative syntax.
 
 * **Address with name:**
 	* `simpleledger:qqmtw4c35mpv5rcjnnsrskpxvzajyq3f9ygldn8fj0?label=Satoshi-Nakamoto`
-	
+
 * **Request 10.0001 XYZ tokens to "Satoshi-Nakamoto":**
   * `simpleledger:qqmtw4c35mpv5rcjnnsrskpxvzajyq3f9ygldn8fj0?amount=20.3&amount=<xyzTokenID>:10.0001&label=Satoshi-Nakamoto`
 


### PR DESCRIPTION
This is an initial URI schema for requesting payments in SLP tokens and a base currency.  Acceptance of this spec is a prerequisite to implementing in EC SLP and should also be completed before merge of EC SLP into main version of Electron Cash. 

https://github.com/simpleledger/Electron-Cash-SLP/issues/63.

Considerations for BIP-70 may need to be added.